### PR TITLE
PostCard、Hashtagの場合分けをしました。

### DIFF
--- a/src/components/atoms/Hashtag/index.tsx
+++ b/src/components/atoms/Hashtag/index.tsx
@@ -3,10 +3,13 @@ import { Pressable } from "native-base";
 import { Color } from "../../../constants/Color";
 import { FontType } from "../../../constants/Font";
 import { CustomText } from "../Text";
+import { color } from "native-base/lib/typescript/theme/styled-system";
 
 export enum HashTagDisplayMode {
   PRIMARY = "primary",
   SECONDARY = "secondary",
+  TLNORMAL = "normal",
+  TLSPECIAL = "special"
 }
 
 interface HashtagProps {
@@ -16,10 +19,32 @@ interface HashtagProps {
 }
 
 const Hashtag: React.FC<HashtagProps> = ({ text, displayMode, onPress }) => {
-  const backgroundColor =
-    displayMode === HashTagDisplayMode.PRIMARY ? Color.MAIN : Color.WHITE_70;
-  const textColor =
-    displayMode === HashTagDisplayMode.PRIMARY ? Color.BASE : Color.MAIN;
+  const style ={
+  [HashTagDisplayMode.PRIMARY]:
+  {"backgroundColor":Color.MAIN,
+  "textColor":Color.BASE,
+  "radiusSize":"18px",
+  "shadowSize":1,
+},
+  [HashTagDisplayMode.SECONDARY]:
+  {"backgroundColor":Color.WHITE_70,
+  "textColor":Color.MAIN,
+  "radiusSize":"18px",
+  "shadowSize":1,
+},
+  [HashTagDisplayMode.TLNORMAL]:
+  {"backgroundColor":Color.WHITE_100,
+  "textColor":Color.THREAD_PURPLE_SUB,
+  "radiusSize":"9px",
+  "shadowSize":"none",
+},
+  [HashTagDisplayMode.TLSPECIAL]:
+  {"backgroundColor":Color.THREAD_PURPLE_SUB,
+  "textColor":Color.WHITE_100,
+  "radiusSize":"9px",
+  "shadowSize":"none",
+}
+    } 
 
   return (
     <Pressable
@@ -29,13 +54,13 @@ const Hashtag: React.FC<HashtagProps> = ({ text, displayMode, onPress }) => {
       display="flex"
       alignItems="center"
       justifyContent="center"
-      borderRadius="18px"
-      backgroundColor={backgroundColor}
-      shadow={1}
+      borderRadius={style[displayMode].radiusSize}
+      backgroundColor={style[displayMode].backgroundColor}
+      shadow={style[displayMode].shadowSize}
       marginTop="6px"
       marginRight="6px"
     >
-      <CustomText color={textColor} fontType={FontType.SMALL}>
+      <CustomText color={style[displayMode].textColor} fontType={FontType.SMALL}>
         {"#" + text}
       </CustomText>
     </Pressable>

--- a/src/components/atoms/Hashtag/index.tsx
+++ b/src/components/atoms/Hashtag/index.tsx
@@ -3,13 +3,12 @@ import { Pressable } from "native-base";
 import { Color } from "../../../constants/Color";
 import { FontType } from "../../../constants/Font";
 import { CustomText } from "../Text";
-import { color } from "native-base/lib/typescript/theme/styled-system";
 
 export enum HashTagDisplayMode {
   PRIMARY = "primary",
   SECONDARY = "secondary",
   TLNORMAL = "normal",
-  TLSPECIAL = "special"
+  TLSPECIAL = "special",
 }
 
 interface HashtagProps {
@@ -19,32 +18,32 @@ interface HashtagProps {
 }
 
 const Hashtag: React.FC<HashtagProps> = ({ text, displayMode, onPress }) => {
-  const style ={
-  [HashTagDisplayMode.PRIMARY]:
-  {"backgroundColor":Color.MAIN,
-  "textColor":Color.BASE,
-  "radiusSize":"18px",
-  "shadowSize":1,
-},
-  [HashTagDisplayMode.SECONDARY]:
-  {"backgroundColor":Color.WHITE_70,
-  "textColor":Color.MAIN,
-  "radiusSize":"18px",
-  "shadowSize":1,
-},
-  [HashTagDisplayMode.TLNORMAL]:
-  {"backgroundColor":Color.WHITE_100,
-  "textColor":Color.THREAD_PURPLE_SUB,
-  "radiusSize":"9px",
-  "shadowSize":"none",
-},
-  [HashTagDisplayMode.TLSPECIAL]:
-  {"backgroundColor":Color.THREAD_PURPLE_SUB,
-  "textColor":Color.WHITE_100,
-  "radiusSize":"9px",
-  "shadowSize":"none",
-}
-    } 
+  const style = {
+    [HashTagDisplayMode.PRIMARY]: {
+      backgroundColor: Color.MAIN,
+      textColor: Color.BASE,
+      radiusSize: "18px",
+      shadowSize: 1,
+    },
+    [HashTagDisplayMode.SECONDARY]: {
+      backgroundColor: Color.WHITE_70,
+      textColor: Color.MAIN,
+      radiusSize: "18px",
+      shadowSize: 1,
+    },
+    [HashTagDisplayMode.TLNORMAL]: {
+      backgroundColor: Color.WHITE_100,
+      textColor: Color.THREAD_PURPLE_SUB,
+      radiusSize: "9px",
+      shadowSize: "none",
+    },
+    [HashTagDisplayMode.TLSPECIAL]: {
+      backgroundColor: Color.THREAD_PURPLE_SUB,
+      textColor: Color.WHITE_100,
+      radiusSize: "9px",
+      shadowSize: "none",
+    },
+  };
 
   return (
     <Pressable
@@ -60,7 +59,10 @@ const Hashtag: React.FC<HashtagProps> = ({ text, displayMode, onPress }) => {
       marginTop="6px"
       marginRight="6px"
     >
-      <CustomText color={style[displayMode].textColor} fontType={FontType.SMALL}>
+      <CustomText
+        color={style[displayMode].textColor}
+        fontType={FontType.SMALL}
+      >
         {"#" + text}
       </CustomText>
     </Pressable>

--- a/src/components/organisms/PostCard/index.tsx
+++ b/src/components/organisms/PostCard/index.tsx
@@ -1,18 +1,29 @@
 import * as React from "react";
-import { Box, VStack, HStack, Divider } from "native-base";
+import { Box, VStack, HStack, Divider, Icon, Text, Spacer } from "native-base";
 import { Color } from "../../../constants/Color";
 import { AlignedHashtags } from "../../molecules/AlignedHashtags";
 import { CustomText } from "../../atoms/Text";
 import { FontType } from "../../../constants/Font";
 import { HashTagDisplayMode } from "../../atoms/Hashtag";
+import { MaterialIcons } from "@expo/vector-icons";
 
 export enum PostCardType {
+  PLANE = "plane",
+  COMMENT = "comment",
+  LIKE = "like",
+  SAVE = "save",
   PREVIEW = "preview",
+  TL = "tl",
+  DETAIL = "detail",
 }
 
 interface PostPreviewProps {
   type: PostCardType;
   authorName: string;
+  postTime: number;
+  likeNum: number;
+  commentNum: number;
+  saveNum: number;
   title: string;
   body: string;
   tags?: any;
@@ -20,17 +31,30 @@ interface PostPreviewProps {
 }
 
 const BackgroundColor = {
+  [PostCardType.PLANE]: Color.WHITE_100,
+  [PostCardType.COMMENT]: Color.WHITE_100,
+  [PostCardType.LIKE]: Color.WHITE_100,
+  [PostCardType.SAVE]: Color.WHITE_100,
   [PostCardType.PREVIEW]: Color.BASE,
+  [PostCardType.TL]: Color.WHITE_100,
+  [PostCardType.DETAIL]: Color.WHITE_100,
 };
 
 const PostCard: React.FC<PostPreviewProps> = ({
   type,
   authorName,
+  postTime,
+  likeNum,
+  commentNum,
+  saveNum,
   title,
   body,
   tags,
   onTagPress,
 }) => {
+  const hashMode =(type===PostCardType.PREVIEW? HashTagDisplayMode.PRIMARY :HashTagDisplayMode.TLNORMAL)
+  const actionButtonSize=6
+
   return (
     <Box
       borderRadius="12px"
@@ -44,6 +68,51 @@ const PostCard: React.FC<PostPreviewProps> = ({
           <CustomText color={Color.TEXT} fontType={FontType.EXSMALL_BOLD}>
             {authorName}
           </CustomText>
+          <Box display="flex" flexDirection="row">
+            {postTime != 0 &&
+              <Text color={Color.TEXT} >
+                {postTime + "時間前"}
+                {/* TODO いい感じに表示を変える */}
+              </Text>
+            }
+            {type == "like" &&
+              <Icon
+                as={<MaterialIcons name={"favorite"} />}
+                size={actionButtonSize}
+                color={Color.MAIN}
+                mt="3px"
+                mr="4px"
+              />
+            }
+            {type == "like" && likeNum != 0 &&
+              <Text color={Color.TEXT} > {likeNum}</Text>
+            }
+            {type == "detail" &&
+              <Icon
+                as={<MaterialIcons name={"chat-bubble-outline"} />}
+                size={actionButtonSize}
+                color={Color.MAIN}
+                mt="3px"
+                mr="4px"
+              />
+            }
+            {type == "detail" && commentNum != 0 &&
+              <Text color={Color.TEXT} > {commentNum}</Text>
+            }
+            {(type == "save" || type == "tl") &&
+              <Icon
+                as={<MaterialIcons name={"turned-in-not"} />}
+                size={actionButtonSize}
+                color={Color.MAIN}
+                mt="3px"
+                mr="4px"
+              />
+            }
+            {type == "tl" && saveNum != 0 &&
+
+              <Text color={Color.TEXT} > {saveNum}</Text>
+            }
+          </Box>
         </HStack>
 
         <Divider
@@ -77,7 +146,7 @@ const PostCard: React.FC<PostPreviewProps> = ({
       <AlignedHashtags
         tags={tags}
         onTagPress={onTagPress}
-        displayMode={HashTagDisplayMode.PRIMARY}
+        displayMode={hashMode}
       />
     </Box>
   );

--- a/src/components/organisms/PostCard/index.tsx
+++ b/src/components/organisms/PostCard/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Box, VStack, HStack, Divider, Icon, Text, Spacer } from "native-base";
+import { Box, VStack, HStack, Divider, Icon, Text } from "native-base";
 import { Color } from "../../../constants/Color";
 import { AlignedHashtags } from "../../molecules/AlignedHashtags";
 import { CustomText } from "../../atoms/Text";
@@ -52,8 +52,11 @@ const PostCard: React.FC<PostPreviewProps> = ({
   tags,
   onTagPress,
 }) => {
-  const hashMode =(type===PostCardType.PREVIEW? HashTagDisplayMode.PRIMARY :HashTagDisplayMode.TLNORMAL)
-  const actionButtonSize=6
+  const hashMode =
+    type === PostCardType.PREVIEW
+      ? HashTagDisplayMode.PRIMARY
+      : HashTagDisplayMode.TLNORMAL;
+  const actionButtonSize = 6;
 
   return (
     <Box
@@ -69,13 +72,13 @@ const PostCard: React.FC<PostPreviewProps> = ({
             {authorName}
           </CustomText>
           <Box display="flex" flexDirection="row">
-            {postTime != 0 &&
-              <Text color={Color.TEXT} >
+            {postTime != 0 && (
+              <Text color={Color.TEXT}>
                 {postTime + "時間前"}
                 {/* TODO いい感じに表示を変える */}
               </Text>
-            }
-            {type == "like" &&
+            )}
+            {type == "like" && (
               <Icon
                 as={<MaterialIcons name={"favorite"} />}
                 size={actionButtonSize}
@@ -83,11 +86,11 @@ const PostCard: React.FC<PostPreviewProps> = ({
                 mt="3px"
                 mr="4px"
               />
-            }
-            {type == "like" && likeNum != 0 &&
-              <Text color={Color.TEXT} > {likeNum}</Text>
-            }
-            {type == "detail" &&
+            )}
+            {type == "like" && likeNum != 0 && (
+              <Text color={Color.TEXT}> {likeNum}</Text>
+            )}
+            {type == "detail" && (
               <Icon
                 as={<MaterialIcons name={"chat-bubble-outline"} />}
                 size={actionButtonSize}
@@ -95,11 +98,11 @@ const PostCard: React.FC<PostPreviewProps> = ({
                 mt="3px"
                 mr="4px"
               />
-            }
-            {type == "detail" && commentNum != 0 &&
-              <Text color={Color.TEXT} > {commentNum}</Text>
-            }
-            {(type == "save" || type == "tl") &&
+            )}
+            {type == "detail" && commentNum != 0 && (
+              <Text color={Color.TEXT}> {commentNum}</Text>
+            )}
+            {(type == "save" || type == "tl") && (
               <Icon
                 as={<MaterialIcons name={"turned-in-not"} />}
                 size={actionButtonSize}
@@ -107,11 +110,10 @@ const PostCard: React.FC<PostPreviewProps> = ({
                 mt="3px"
                 mr="4px"
               />
-            }
-            {type == "tl" && saveNum != 0 &&
-
-              <Text color={Color.TEXT} > {saveNum}</Text>
-            }
+            )}
+            {type == "tl" && saveNum != 0 && (
+              <Text color={Color.TEXT}> {saveNum}</Text>
+            )}
           </Box>
         </HStack>
 

--- a/src/components/screens/SelectHashtag/index.tsx
+++ b/src/components/screens/SelectHashtag/index.tsx
@@ -76,6 +76,10 @@ export const SelectHashTag: React.FC<SelectHashtagScreenProps> = ({
             <PostCard
               type={PostCardType.PREVIEW}
               authorName="ピヨ子"
+              postTime={1}
+              likeNum={0}
+              commentNum={0}
+              saveNum={0}
               title="研究の仕方が全く分かりません！つらいです。右も左も分からない人に研究計画書書かせるとかありえなくないですか？"
               body="研究マジでつらいです。右も左も分からない人に研究計画書書かせるとかありえなくないですか？研究マジでつらいです。右も左も分からない人に研究計画書書かせるとかありえなくないですか？"
               tags={selectedTags}


### PR DESCRIPTION
FigmaからはactionButton-PostCard右上のボタン-が押されたときのactionButtonの表示の変化がわからなかったので適当になっています。
具体的には
- 吹き出しマークはどのような場合に現れるのか。吹き出しマークがないPostCardがあります。
- プロフィール画面のいいね、保存画面で「いいね」や「保存」を押すとどうなるのか。即座に消えるのか、一定時間後に消えるのか、画面が遷移するまで消えないのか。その際マークの中の色はどうなるのか。
上記のマークの色や押下の可否はユーザーの行動履歴に基づくものが多いため、実装方法を相談してからにしようと思いました。
あと、material iconsで丸い形の吹き出しを見つけられませんでした。