### PR TITLE
検索画面のレイアウトを作成しました

### DIFF
--- a/src/components/organisms/PostCard/index.tsx
+++ b/src/components/organisms/PostCard/index.tsx
@@ -57,7 +57,7 @@ const PostCard: React.FC<PostPreviewProps> = ({
     type === PostCardType.PREVIEW
       ? HashTagDisplayMode.PRIMARY
       : HashTagDisplayMode.TLNORMAL;
-  const actionButtonSize = "6px";
+  const actionButtonSize = "30px";
 
   return (
     <Box

--- a/src/components/organisms/SearchTabbar/index.tsx
+++ b/src/components/organisms/SearchTabbar/index.tsx
@@ -1,0 +1,63 @@
+import { Box, HStack, Pressable } from "native-base";
+import * as React from "react";
+import { Color } from "../../../constants/Color";
+import { Dimensions } from "react-native";
+import { CustomMaterialIcon } from "../../atoms/MaterialIcon";
+import { IconName } from "../../../constants/IconName";
+
+export enum SearchTab {
+  HASH = "hashtag",
+  KEYWORD = "keyword",
+  ACCOUNT = "account",
+}
+
+const tabs = [SearchTab.HASH, SearchTab.KEYWORD, SearchTab.ACCOUNT];
+
+const SearchTabIcon = {
+  [SearchTab.HASH]: IconName.TAG,
+  [SearchTab.KEYWORD]: IconName.MENU,
+  [SearchTab.ACCOUNT]: IconName.PERSON,
+};
+
+interface SearchTabbarProps {
+  currentTab: SearchTab;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onCurrentTabChange: (tab: SearchTab) => void;
+}
+
+export const SearchTabbar: React.FC<SearchTabbarProps> = ({
+  currentTab,
+  onCurrentTabChange,
+}) => {
+  const screenWidth = Dimensions.get("window").width;
+  const currentTabWidth = screenWidth - 64 * 4;
+  return (
+    <Box display="flex" flexDirection="row" height={12}>
+      {tabs.map((tab) => (
+        <Pressable
+          height={12}
+          // color={tab === currentTab ? Color.SUB : Color.WHITE_100}
+          backgroundColor={tab === currentTab ? Color.SUB : Color.WHITE_100}
+          width={currentTabWidth}
+          shadow="1"
+          borderTopRadius="12px"
+          onPress={() => {
+            onCurrentTabChange(tab);
+          }}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          key={tab}
+        >
+          <HStack alignItems="center" space="4px">
+            <CustomMaterialIcon
+              size="24px"
+              color={Color.BLACK_30}
+              name={SearchTabIcon[tab]}
+            />
+          </HStack>
+        </Pressable>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/screens/SearchScreen/hooks.ts
+++ b/src/components/screens/SearchScreen/hooks.ts
@@ -1,0 +1,42 @@
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ScreenName } from "../../../constants/ScreenName";
+import { Post, PostType } from "../../../domain/types/Post";
+import { useAuth } from "../../../providers/AuthProvider/hooks";
+import { PostRepository } from "../../../repositories/PostRepository";
+import { AlertButtonStyle, useAlert } from "../../../utils/useAlert";
+import { DisplayMode } from ".";
+
+export const useSearch = () => {
+  const [displayMode, setDisplayMode] = useState(DisplayMode.RANK);
+  const [searching, setSearching] = useState<boolean>(false);
+  const [searchWord, setSearchWord] = useState<string>("");
+
+  const unFocus = () => {
+    if (searching) {
+      // setDisplayMode(DisplayMode.RESULT);
+      return;
+    } else {
+      setDisplayMode(DisplayMode.RANK);
+    }
+  };
+  const search = () => {
+    setSearching(true);
+    setDisplayMode(DisplayMode.RESULT);
+  };
+  const gotoRank = () => {
+    setSearching(false);
+    setSearchWord("");
+    setDisplayMode(DisplayMode.RANK);
+  };
+
+  return {
+    displayMode,
+    setDisplayMode,
+    searchWord,
+    setSearchWord,
+    search,
+    unFocus,
+    gotoRank,
+  };
+};

--- a/src/components/screens/SearchScreen/index.tsx
+++ b/src/components/screens/SearchScreen/index.tsx
@@ -1,0 +1,222 @@
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import {
+  HStack,
+  KeyboardAvoidingView,
+  Pressable,
+  Box,
+  Input,
+  ScrollView,
+  VStack,
+} from "native-base";
+import * as React from "react";
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useState } from "react";
+import { Color } from "../../../constants/Color";
+import { IconName } from "../../../constants/IconName";
+import { CustomMaterialIcon } from "../../atoms/MaterialIcon";
+import { PostCard, PostCardType } from "../../organisms/PostCard";
+import { AlignedHashtags } from "../../molecules/AlignedHashtags";
+import { HashTagDisplayMode } from "../../atoms/Hashtag";
+import { SearchTabbar, SearchTab } from "../../organisms/SearchTabbar";
+import { useSearch } from "./hooks";
+// import { useSearchScreen } from "./hooks";
+
+export enum DisplayMode {
+  RANK = "ranking",
+  HASH = "hashtag",
+  RESULT = "result",
+}
+export interface SearchScreenProps {
+  navigation: NativeStackNavigationProp<any, any>;
+}
+
+export const SearchScreen: React.FC<SearchScreenProps> = ({ navigation }) => {
+  const [currentTab, setCurrentTab] = useState<SearchTab>(SearchTab.HASH);
+  const insets = useSafeAreaInsets();
+  const getMainPane = () => {
+    switch (currentTab) {
+      case SearchTab.HASH:
+        return <></>;
+      case SearchTab.KEYWORD:
+        return (
+          <VStack mx="15px" mt="10px" space="5px">
+            <PostCard
+              type={PostCardType.SAVE}
+              authorName="ぴよ"
+              postTime={100}
+              likeNum={10000}
+              commentNum={100}
+              saveNum={0}
+              title="hoge"
+              body="hogehoge"
+              tags={["きく"]}
+              onTagPress={() => {}}
+            />
+            <PostCard
+              type={PostCardType.SAVE}
+              authorName="ぴよ"
+              postTime={100}
+              likeNum={10000}
+              commentNum={100}
+              saveNum={0}
+              title="hoge"
+              body="hogehoge"
+              tags={["きく"]}
+              onTagPress={() => {}}
+            />
+            <PostCard
+              type={PostCardType.SAVE}
+              authorName="ぴよ"
+              postTime={100}
+              likeNum={10000}
+              commentNum={100}
+              saveNum={0}
+              title="hoge"
+              body="hogehoge"
+              tags={["きく"]}
+              onTagPress={() => {}}
+            />
+          </VStack>
+        );
+      case SearchTab.ACCOUNT:
+        return <></>;
+    }
+  };
+  const {
+    displayMode,
+    setDisplayMode,
+    searchWord,
+    setSearchWord,
+    search,
+    unFocus,
+    gotoRank,
+  } = useSearch();
+  return (
+    <KeyboardAvoidingView
+      flex={1}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      bg={Color.BASE}
+    >
+      <ScrollView bg={Color.BASE} flex={1}>
+        <VStack marginTop={`${insets.top}px`}>
+          <HStack mt="8px" mx="24px" alignItems="center" space="8px">
+            {!(displayMode == DisplayMode.RANK) && (
+              <Pressable position="relative" onPress={gotoRank}>
+                <CustomMaterialIcon
+                  size="28px"
+                  color={Color.MAIN}
+                  name={IconName.ARROW_BACK}
+                />
+              </Pressable>
+            )}
+            <Box
+              flex={1}
+              borderWidth="1px"
+              borderColor={Color.MEDIUM_GRAY}
+              borderRadius="12px"
+              shadow={1}
+            >
+              <Input
+                placeholder={
+                  searchWord == ""
+                    ? "ハッシュタグ、ユーザー、キーワード検索"
+                    : searchWord
+                }
+                height="40px"
+                width="100%"
+                borderRadius="12px"
+                backgroundColor={Color.WHITE_100}
+                shadow="2"
+                borderWidth="0"
+                fontFamily="body"
+                fontWeight={500}
+                fontSize="xs"
+                multiline={false}
+                onFocus={() => setDisplayMode(DisplayMode.HASH)}
+                onSubmitEditing={() => search()}
+                onBlur={() => unFocus()}
+                value={searchWord}
+                onChangeText={setSearchWord}
+                InputLeftElement={
+                  <Box ml="10px">
+                    <CustomMaterialIcon
+                      name={IconName.SEARCH}
+                      size="24px"
+                      color={Color.MEDIUM_GRAY}
+                    />
+                  </Box>
+                }
+              />
+            </Box>
+          </HStack>
+          {displayMode == DisplayMode.RANK && (
+            <VStack mx="15px" mt="10px" space="5px">
+              <PostCard
+                type={PostCardType.SAVE}
+                authorName="ぴよ"
+                postTime={100}
+                likeNum={10000}
+                commentNum={100}
+                saveNum={0}
+                title="hoge"
+                body="hogehoge"
+                tags={["きく"]}
+                onTagPress={() => {}}
+              />
+              <PostCard
+                type={PostCardType.SAVE}
+                authorName="ぴよ"
+                postTime={100}
+                likeNum={10000}
+                commentNum={100}
+                saveNum={0}
+                title="hoge"
+                body="hogehoge"
+                tags={["きく"]}
+                onTagPress={() => {}}
+              />
+              <PostCard
+                type={PostCardType.SAVE}
+                authorName="ぴよ"
+                postTime={100}
+                likeNum={10000}
+                commentNum={100}
+                saveNum={0}
+                title="hoge"
+                body="hogehoge"
+                tags={["きく"]}
+                onTagPress={() => {}}
+              />
+            </VStack>
+          )}
+          {displayMode == DisplayMode.HASH && (
+            <Box mx="15px" mt="10px">
+              <AlignedHashtags
+                tags={[
+                  "東大",
+                  "工学系研究科",
+                  "物理工学専攻",
+                  "physics",
+                  "Nature",
+                  "Nature Physics",
+                ]}
+                displayMode={HashTagDisplayMode.SECONDARY}
+                onTagPress={() => {}}
+              />
+            </Box>
+          )}
+          {displayMode == DisplayMode.RESULT && (
+            <VStack mt="10px">
+              <SearchTabbar
+                currentTab={currentTab}
+                onCurrentTabChange={setCurrentTab}
+              />
+              {getMainPane()}
+            </VStack>
+          )}
+        </VStack>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};

--- a/src/constants/IconName.ts
+++ b/src/constants/IconName.ts
@@ -29,4 +29,7 @@ export enum IconName {
   SETTING = "settings",
   BOOK = "menu-book",
   DESCRIPTION = "portrait",
+  SEARCH = "search",
+  TAG = "tag",
+  MENU = "menu",
 }

--- a/src/screenGroups/MainTab/index.tsx
+++ b/src/screenGroups/MainTab/index.tsx
@@ -2,6 +2,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as React from "react";
 import { Tabbar } from "../../components/organisms/Tabbar";
 import { HomeScreen } from "../../components/screens/HomeScreen";
+import { SearchScreen } from "../../components/screens/SearchScreen";
 import { ScreenName } from "../../constants/ScreenName";
 import { ProfileStack } from "../ProfileStack";
 
@@ -18,7 +19,7 @@ export const MainTab: React.FC = () => {
       tabBar={(props) => <Tabbar {...props} />}
     >
       <Tab.Screen name={ScreenName.HOME} component={HomeScreen} />
-      <Tab.Screen name={ScreenName.SEARCH} component={HomeScreen} />
+      <Tab.Screen name={ScreenName.SEARCH} component={SearchScreen} />
       <Tab.Screen name={ScreenName.PLACEHOLDER} component={PlaceHolder} />
       <Tab.Screen name={ScreenName.NOTIFICATION} component={HomeScreen} />
       <Tab.Screen name={ScreenName.PROFILE} component={ProfileStack} />


### PR DESCRIPTION
検索結果のタブ切り替えによって被選択タブの色をその下の検索結果の領域の色にそろえることができていません
デザインチャンネルで議論されていましたが、Figmaの「ハッシュタグ検索」の色は既定の色にないため、とりあえずColor.SUBにそろえることを目指しました
しかしpressableでcolorが使えずbgcolorで指定すると色が勝手に変わってしまいます
またmap関数の変数(?)はその直下の要素にしか使えない(?)ことからpressableをほかのcolorが使える要素(boxなど)で囲うこともできません